### PR TITLE
[FEAT] 롤링페이퍼 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/hackathonbe/follow/entity/FollowEntity.java
+++ b/src/main/java/com/example/hackathonbe/follow/entity/FollowEntity.java
@@ -1,0 +1,34 @@
+package com.example.hackathonbe.follow.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class FollowEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "bigint", nullable = false)
+    private Long id;
+
+    @Column(columnDefinition = "bigint", nullable = false)
+    private Long fromUserId;
+
+    @Column(columnDefinition = "bigint", nullable = false)
+    private Long toUserId;
+
+    @Column(columnDefinition = "timestamp", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    private static FollowEntity create(Long from_user_id, Long to_user_id) {
+        FollowEntity followEntity = new FollowEntity();
+        followEntity.fromUserId = from_user_id;
+        followEntity.toUserId = to_user_id;
+
+        return followEntity;
+    }
+}

--- a/src/main/java/com/example/hackathonbe/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/hackathonbe/follow/repository/FollowRepository.java
@@ -1,0 +1,12 @@
+package com.example.hackathonbe.follow.repository;
+
+import com.example.hackathonbe.follow.entity.FollowEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FollowRepository extends JpaRepository<FollowEntity, Long> {
+    List<FollowEntity> findAllByFromUserId(Long id);
+}

--- a/src/main/java/com/example/hackathonbe/global/config/ErrorCode.java
+++ b/src/main/java/com/example/hackathonbe/global/config/ErrorCode.java
@@ -10,7 +10,13 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 @AllArgsConstructor
 public enum ErrorCode {
     // AUTH
-    AUTH_REQUIRED(BAD_REQUEST, "로그인이 필요한 서비스입니다.");
+    AUTH_REQUIRED(BAD_REQUEST, "로그인이 필요한 서비스입니다."),
+
+    // PAPER
+    NO_PAPERS_FOUND(BAD_REQUEST, "생성된 페이지가 없습니다."),
+
+    // Follow
+    NO_FRIEND_FOUND(BAD_REQUEST, "친구가 없습니다.");
 
     private final HttpStatus code;
     private final String message;

--- a/src/main/java/com/example/hackathonbe/message/entity/MessageEntity.java
+++ b/src/main/java/com/example/hackathonbe/message/entity/MessageEntity.java
@@ -1,0 +1,42 @@
+package com.example.hackathonbe.message.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MessageEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "bigint", nullable = false)
+    private Long id;
+
+    @Column(columnDefinition = "varchar(36)", nullable = false)
+    private String uuid;
+
+    @Column(columnDefinition = "varchar(8)", nullable = false)
+    private String name;
+
+    @Column(columnDefinition = "varchar(20)", nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "varchar(300)", nullable = false)
+    private String content;
+
+    @Column(columnDefinition = "timestamp", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public static MessageEntity create(String uuid, String name, String title, String content) {
+        MessageEntity messageEntity = new MessageEntity();
+        messageEntity.uuid = uuid;
+        messageEntity.name = name;
+        messageEntity.title = title;
+        messageEntity.content = content;
+
+        return messageEntity;
+    }
+}

--- a/src/main/java/com/example/hackathonbe/paper/controller/PaperController.java
+++ b/src/main/java/com/example/hackathonbe/paper/controller/PaperController.java
@@ -3,9 +3,11 @@ package com.example.hackathonbe.paper.controller;
 import com.example.hackathonbe.global.Path.ApiPath;
 import com.example.hackathonbe.global.config.annotation.RequireLogin;
 import com.example.hackathonbe.global.response.ApiResponse;
-import com.example.hackathonbe.paper.dto.CreatePaperRequestDto;
-import com.example.hackathonbe.paper.dto.CreatePaperResponseDto;
+import com.example.hackathonbe.paper.dto.*;
 import com.example.hackathonbe.paper.service.CreatePaperService;
+import com.example.hackathonbe.paper.service.GetFriendsPaperService;
+import com.example.hackathonbe.paper.service.GetMyPaperService;
+import com.example.hackathonbe.paper.service.GetPublicPaperService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,15 +16,43 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class PaperController {
     private final CreatePaperService createPaperService;
+    private final GetMyPaperService getMyPaperService;
+    private final GetFriendsPaperService getFriendsPaperService;
+    private final GetPublicPaperService getPublicPaperService;
 
     @RequireLogin
-    @PostMapping("/paper/create")
+    @PostMapping("/paper")
     public ApiResponse<CreatePaperResponseDto> createPaper(
-            @RequestHeader(value = "userId", required = true)
+            @RequestHeader(value = "userId", required = true) Long userId,
             @RequestBody CreatePaperRequestDto createPaperRequestDto
     ) {
         createPaperService.create(createPaperRequestDto);
 
         return ApiResponse.ok(new CreatePaperResponseDto());
+    }
+
+    @GetMapping("/paper/my")
+    public ApiResponse<GetMyPaperResponseDto> getMyPaper(
+            @RequestHeader(value = "userId", required = true) Long userId
+    ) {
+        GetMyPaperResponseDto getMyPaperResponseDto = getMyPaperService.get(userId);
+
+        return ApiResponse.ok(getMyPaperResponseDto);
+    }
+
+    @GetMapping("/paper/friends")
+    public ApiResponse<GetFriendsPaperResponseDto> getFriendsPaper(
+            @RequestHeader(value = "userId", required = true) Long userId
+    ) {
+        GetFriendsPaperResponseDto getFriendsPaperResponseDto = getFriendsPaperService.get(userId);
+
+        return ApiResponse.ok(getFriendsPaperResponseDto);
+    }
+
+    @GetMapping("/paper/public")
+    public ApiResponse<GetPublicPaperResponseDto> getPublicPaper() {
+        GetPublicPaperResponseDto getPublicPaperResponseDto = getPublicPaperService.get();
+
+        return ApiResponse.ok(getPublicPaperResponseDto);
     }
 }

--- a/src/main/java/com/example/hackathonbe/paper/dto/CreatePaperRequestDto.java
+++ b/src/main/java/com/example/hackathonbe/paper/dto/CreatePaperRequestDto.java
@@ -1,6 +1,6 @@
 package com.example.hackathonbe.paper.dto;
 
-import com.example.hackathonbe.paper.entity.Category;
+import com.example.hackathonbe.paper.entity.enums.Category;
 import com.example.hackathonbe.paper.entity.enums.VisibilityScope;
 import jakarta.annotation.Nullable;
 import lombok.Getter;

--- a/src/main/java/com/example/hackathonbe/paper/dto/GetFriendsPaperResponseDto.java
+++ b/src/main/java/com/example/hackathonbe/paper/dto/GetFriendsPaperResponseDto.java
@@ -1,0 +1,8 @@
+package com.example.hackathonbe.paper.dto;
+
+import com.example.hackathonbe.paper.entity.PaperEntity;
+
+import java.util.List;
+
+public record GetFriendsPaperResponseDto(List<PaperEntity> paperEntityList) {
+}

--- a/src/main/java/com/example/hackathonbe/paper/dto/GetMyPaperResponseDto.java
+++ b/src/main/java/com/example/hackathonbe/paper/dto/GetMyPaperResponseDto.java
@@ -1,0 +1,8 @@
+package com.example.hackathonbe.paper.dto;
+
+import com.example.hackathonbe.paper.entity.PaperEntity;
+
+import java.util.List;
+
+public record GetMyPaperResponseDto(List<PaperEntity> paperEntityList) {
+}

--- a/src/main/java/com/example/hackathonbe/paper/dto/GetPublicPaperResponseDto.java
+++ b/src/main/java/com/example/hackathonbe/paper/dto/GetPublicPaperResponseDto.java
@@ -1,0 +1,8 @@
+package com.example.hackathonbe.paper.dto;
+
+import com.example.hackathonbe.paper.entity.PaperEntity;
+
+import java.util.List;
+
+public record GetPublicPaperResponseDto(List<PaperEntity> paperEntityList) {
+}

--- a/src/main/java/com/example/hackathonbe/paper/entity/PaperEntity.java
+++ b/src/main/java/com/example/hackathonbe/paper/entity/PaperEntity.java
@@ -1,6 +1,7 @@
-package com.example.hackathonbe.paper.entity.enums;
+package com.example.hackathonbe.paper.entity;
 
-import com.example.hackathonbe.paper.entity.Category;
+import com.example.hackathonbe.paper.entity.enums.Category;
+import com.example.hackathonbe.paper.entity.enums.VisibilityScope;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,6 +11,9 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
+@Table(
+        indexes = @Index(name = "idx_owner", columnList = "owner") // 페이퍼 리스트 조회할 때 owner 기준으로 가져오기 때문에 인덱스 생성
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PaperEntity {
@@ -21,7 +25,7 @@ public class PaperEntity {
     private Long owner;
 
     @Column(columnDefinition = "timestamp", nullable = false)
-    private LocalDateTime publish_date;
+    private LocalDateTime publishDate;
 
     @Column(columnDefinition = "varchar(20)", nullable = false)
     private String title;
@@ -35,17 +39,17 @@ public class PaperEntity {
     private Category category;
 
     @Column(columnDefinition = "timestamp", nullable = false)
-    private LocalDateTime created_at;
+    private LocalDateTime createdAt;
 
     public static PaperEntity create(Long owner, LocalDateTime publish_date, String title, VisibilityScope visibilityScope, Category category) {
         PaperEntity paperEntity = new PaperEntity();
         paperEntity.uuid = UUID.randomUUID().toString();
         paperEntity.owner = owner;
-        paperEntity.publish_date = publish_date;
+        paperEntity.publishDate = publish_date;
         paperEntity.title = title;
         paperEntity.visibilityScope = visibilityScope;
         paperEntity.category = category;
-        paperEntity.created_at = LocalDateTime.now();
+        paperEntity.createdAt = LocalDateTime.now();
 
         return paperEntity;
     }

--- a/src/main/java/com/example/hackathonbe/paper/entity/enums/Category.java
+++ b/src/main/java/com/example/hackathonbe/paper/entity/enums/Category.java
@@ -1,4 +1,4 @@
-package com.example.hackathonbe.paper.entity;
+package com.example.hackathonbe.paper.entity.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/example/hackathonbe/paper/repository/PaperRepository.java
+++ b/src/main/java/com/example/hackathonbe/paper/repository/PaperRepository.java
@@ -1,9 +1,17 @@
 package com.example.hackathonbe.paper.repository;
 
-import com.example.hackathonbe.paper.entity.enums.PaperEntity;
+import com.example.hackathonbe.paper.entity.PaperEntity;
+import com.example.hackathonbe.paper.entity.enums.VisibilityScope;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PaperRepository extends JpaRepository<PaperEntity, Long> {
+    List<PaperEntity> findAllByOwner(Long userId);
+
+    List<PaperEntity> findAllByVisibilityScope(VisibilityScope visibilityScope);
+
+    List<PaperEntity> findAllByOwnerIn(List<Long> userIdList);
 }

--- a/src/main/java/com/example/hackathonbe/paper/service/CreatePaperService.java
+++ b/src/main/java/com/example/hackathonbe/paper/service/CreatePaperService.java
@@ -1,7 +1,7 @@
 package com.example.hackathonbe.paper.service;
 
 import com.example.hackathonbe.paper.dto.CreatePaperRequestDto;
-import com.example.hackathonbe.paper.entity.enums.PaperEntity;
+import com.example.hackathonbe.paper.entity.PaperEntity;
 import com.example.hackathonbe.paper.repository.PaperRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/hackathonbe/paper/service/GetFriendsPaperService.java
+++ b/src/main/java/com/example/hackathonbe/paper/service/GetFriendsPaperService.java
@@ -1,0 +1,30 @@
+package com.example.hackathonbe.paper.service;
+
+import com.example.hackathonbe.follow.repository.FollowRepository;
+import com.example.hackathonbe.global.config.BusinessException;
+import com.example.hackathonbe.global.config.ErrorCode;
+import com.example.hackathonbe.paper.dto.GetFriendsPaperResponseDto;
+import com.example.hackathonbe.paper.entity.PaperEntity;
+import com.example.hackathonbe.paper.repository.PaperRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetFriendsPaperService {
+    private final FollowRepository followRepository;
+    private final PaperRepository paperRepository;
+
+    public GetFriendsPaperResponseDto get(Long id) {
+        List<Long> friendIdsList = followRepository.findAllByFromUserId(id).stream().map(it -> it.getToUserId()).toList();
+        if (friendIdsList.isEmpty()) { // 친구가 없으면 에러 내리기
+            throw new BusinessException(ErrorCode.NO_FRIEND_FOUND);
+        }
+
+        List<PaperEntity> paperEntityList = paperRepository.findAllByOwnerIn(friendIdsList); // 우선 In 사용해서 가져오게 디자인. 추후 Exists 사용하게 변경할 수도 있음
+
+        return new GetFriendsPaperResponseDto(paperEntityList);
+    }
+}

--- a/src/main/java/com/example/hackathonbe/paper/service/GetMyPaperService.java
+++ b/src/main/java/com/example/hackathonbe/paper/service/GetMyPaperService.java
@@ -1,0 +1,26 @@
+package com.example.hackathonbe.paper.service;
+
+import com.example.hackathonbe.global.config.BusinessException;
+import com.example.hackathonbe.global.config.ErrorCode;
+import com.example.hackathonbe.paper.dto.GetMyPaperResponseDto;
+import com.example.hackathonbe.paper.entity.PaperEntity;
+import com.example.hackathonbe.paper.repository.PaperRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetMyPaperService {
+    private final PaperRepository paperRepository;
+
+    public GetMyPaperResponseDto get(Long userId) {
+        List<PaperEntity> paperEntityList = paperRepository.findAllByOwner(userId);
+        if (paperEntityList.isEmpty()) { // 조회 결과가 없는 경우에 에러 내림
+            throw new BusinessException(ErrorCode.NO_PAPERS_FOUND);
+        }
+
+        return new GetMyPaperResponseDto(paperEntityList);
+    }
+}

--- a/src/main/java/com/example/hackathonbe/paper/service/GetPublicPaperService.java
+++ b/src/main/java/com/example/hackathonbe/paper/service/GetPublicPaperService.java
@@ -1,0 +1,27 @@
+package com.example.hackathonbe.paper.service;
+
+import com.example.hackathonbe.global.config.BusinessException;
+import com.example.hackathonbe.global.config.ErrorCode;
+import com.example.hackathonbe.paper.dto.GetPublicPaperResponseDto;
+import com.example.hackathonbe.paper.entity.PaperEntity;
+import com.example.hackathonbe.paper.entity.enums.VisibilityScope;
+import com.example.hackathonbe.paper.repository.PaperRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetPublicPaperService {
+    private final PaperRepository paperRepository;
+
+    public GetPublicPaperResponseDto get() {
+        List<PaperEntity> paperEntity = paperRepository.findAllByVisibilityScope(VisibilityScope.PUBLIC);
+        if (paperEntity.isEmpty()) { // 조회 결과가 없는 경우에 에러 내림
+            throw new BusinessException(ErrorCode.NO_PAPERS_FOUND);
+        }
+
+        return new GetPublicPaperResponseDto(paperEntity);
+    }
+}


### PR DESCRIPTION
- 나, 친구, 공개 3가지로 나누어 api 구현하였습니다.
- 친구의 롤링페이퍼를 가져오는 경우에는, 먼저 follow 테이블에서 내가 팔로우한 userId 목록을 조회한 뒤, paper 테이블에서 IN 조건으로 한 번에 조회하도록 구성했습니다.
- IN 절은 데이터가 많아질수록 성능 이슈가 있을 수 있으므로, 추후 EXISTS 조건을 사용하도록 개선해두겠습니다.

- entity 모두 만들어두었습니다!