### PR TITLE
[FEAT] 에러 메세지 응답 형식 수정

### DIFF
--- a/src/main/java/com/example/hackathonbe/global/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/hackathonbe/global/config/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.hackathonbe.global.config;
 
+import com.example.hackathonbe.global.response.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -13,17 +14,23 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ResponseEntity<?> handleNoResourceFoundException(NoResourceFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.from(ex.getMessage()));
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseEntity<?> handleMissingServletRequestParameterException(MissingServletRequestParameterException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.from(ex.getMessage()));
     }
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<?> handleBusinessException(BusinessException ex) {
-        return ResponseEntity.status(ex.getErrorCode().getCode()).body(ex.getMessage());
+        return ResponseEntity
+                .status(ex.getErrorCode().getCode())
+                .body(ErrorResponse.from(ex.getMessage()));
     }
 }

--- a/src/main/java/com/example/hackathonbe/global/response/ErrorResponse.java
+++ b/src/main/java/com/example/hackathonbe/global/response/ErrorResponse.java
@@ -9,10 +9,10 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ApiResponse<T> {
-    private T data;
+public class ErrorResponse {
+    private String message;
 
-    public static <T> ApiResponse<T> ok(T data) {
-        return new ApiResponse<>(data);
+    public static ErrorResponse from(String message) {
+        return new ErrorResponse(message);
     }
 }


### PR DESCRIPTION
[AS-IS]
- 기존에 에러 발생 시 응답 바디에 json 형식이 아닌 String 자체가 바로 응답가는 문제가 있었습니다.

[TO-BE]
- 에러 발생 시 json 형식에 맞게 {message: "메세지"} 구조로 응답가도록 수정했습니다.